### PR TITLE
Organize repository docs and refresh project guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,26 @@
-.venv/
+# Python bytecode and caches
 __pycache__/
-*.pyc
+*.py[cod]
+*.pyo
+*.pyd
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local tool/editor files
+.DS_Store
+
+# Build and packaging outputs
+build/
+dist/
+*.egg-info/
+
+# Experiment outputs
 artifacts/
 artifacts_*/
-pytest_cache/
+artifacts_smoke/

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,54 @@
+# PRODUCT.md
+
+## Product Purpose
+
+`graph_invariant` is a research tool for discovering useful graph invariants with LLM-assisted search.  
+It aims to help researchers generate, evaluate, and compare candidate formulas against known structural graph metrics.
+
+## Target Users
+
+- Graph/network science researchers
+- Applied ML researchers exploring symbolic discovery
+- Engineers prototyping interpretable graph descriptors
+
+## Core User Problems
+
+- Finding high-signal graph descriptors is slow and manual.
+- Candidate formulas are hard to compare consistently across datasets.
+- Reproducibility is difficult without standardized artifacts and checkpoints.
+
+## Key Features
+
+- Deterministic graph dataset generation for train/validation/test splits
+- LLM-driven candidate generation with island-style exploration
+- Sandboxed candidate execution with timeout and memory constraints
+- Composite scoring:
+  - predictive quality
+  - simplicity
+  - novelty vs known invariants
+- Baseline comparisons (statistical + optional PySR)
+- JSON/JSONL artifacts, checkpoints, and markdown report generation
+- Multi-seed benchmark mode
+
+## Product Objectives
+
+- Short term:
+  - Provide a reliable Phase 1 research loop with reproducible outputs.
+  - Make experiment outcomes auditable through structured artifacts.
+- Medium term:
+  - Improve discovery quality under fixed compute budgets.
+  - Improve reliability of novelty and baseline comparisons.
+- Long term:
+  - Support publication-quality experiments and OSS reuse.
+
+## Non-Goals (Current Scope)
+
+- Production-grade sandboxing for arbitrary third-party code
+- Distributed cluster orchestration
+- Web UI and managed experiment tracking platform
+
+## Success Criteria
+
+- Pipeline completes end-to-end from config to report.
+- CI stays green with deterministic tests.
+- Artifacts are sufficient to reproduce and review experiment outcomes.

--- a/README.md
+++ b/README.md
@@ -1,72 +1,113 @@
 # graph_invariant
 
-Phase 1 MVP for LLM-driven graph invariant discovery.
+LLM-driven graph invariant discovery for research workflows.  
+This repository contains a Phase 1 implementation (data generation, candidate search/evaluation, novelty scoring, baselines, and reporting) plus the project specification documents.
+
+## What This Project Does
+
+- Generates synthetic graph datasets and target values.
+- Uses an island-style evolutionary loop to search candidate invariants from an LLM.
+- Evaluates candidates with a constrained Python sandbox.
+- Scores by accuracy, simplicity, and novelty against known invariants.
+- Produces reproducible JSON/JSONL artifacts, checkpoints, and markdown reports.
+
+## Requirements
+
+- Python 3.11+
+- `uv` for environment/dependency management
+- Optional: local Ollama model for candidate generation (default model: `gpt-oss:20b`)
 
 ## Quickstart
 
-1. Install dependencies with `uv`:
+1. Install dependencies:
 
 ```bash
 uv sync --group dev
 ```
 
-2. Run tests and lint:
+2. Run local quality checks (same gates as CI):
 
 ```bash
-uv run --group dev pytest
 uv run --group dev ruff check .
 uv run --group dev ruff format --check .
+uv run --group dev pytest -q
 ```
 
-These commands mirror the `Python CI` GitHub Actions workflow.
-
-3. Run a small Phase 1 execution:
+3. Run Phase 1 with a small config:
 
 ```bash
 cat > /tmp/phase1_config.json <<'JSON'
-{"num_train_graphs": 2, "num_val_graphs": 3, "num_test_graphs": 2, "timeout_sec": 0.5, "artifacts_dir": "artifacts_smoke"}
+{
+  "num_train_graphs": 2,
+  "num_val_graphs": 3,
+  "num_test_graphs": 2,
+  "timeout_sec": 0.5,
+  "artifacts_dir": "artifacts_smoke"
+}
 JSON
 uv run python -m graph_invariant.cli phase1 --config /tmp/phase1_config.json
 ```
 
-Artifacts are written under `artifacts*/logs` and `artifacts*/checkpoints`.
-Additional summary artifacts:
-- `artifacts*/phase1_summary.json`
-- `artifacts*/baselines_summary.json` (only when `run_baselines=true`)
-
-`phase1_summary.json` now uses `schema_version=3`. The report command remains tolerant of older payloads.
-
-4. Generate a markdown report from artifacts:
+4. Generate a report:
 
 ```bash
 uv run python -m graph_invariant.cli report --artifacts artifacts_smoke
 ```
 
-This writes `artifacts_smoke/report.md`.
-
-5. Run a multi-seed benchmark sweep:
+5. Run multi-seed benchmark:
 
 ```bash
 cat > /tmp/benchmark_config.json <<'JSON'
-{"benchmark_seeds": [11, 22, 33], "max_generations": 0, "run_baselines": true, "artifacts_dir": "artifacts_benchmark"}
+{
+  "benchmark_seeds": [11, 22, 33],
+  "max_generations": 0,
+  "run_baselines": true,
+  "artifacts_dir": "artifacts_benchmark"
+}
 JSON
 uv run python -m graph_invariant.cli benchmark --config /tmp/benchmark_config.json
 ```
 
-This writes one benchmark directory under `artifacts_benchmark/benchmark_*` with:
-- `benchmark_summary.json`
-- `benchmark_report.md`
-- per-seed subdirectories (`seed_<N>/`) containing regular Phase 1 artifacts.
+## CLI Commands
 
-## Optional Baseline Dependencies
+- `uv run python -m graph_invariant.cli phase1 --config <config.json> [--resume <checkpoint.json>]`
+- `uv run python -m graph_invariant.cli report --artifacts <artifacts_dir>`
+- `uv run python -m graph_invariant.cli benchmark --config <config.json>`
 
-`run_baselines` is disabled by default. If enabled:
-- Linear regression baseline uses NumPy only.
-- Random forest baseline requires `scikit-learn`.
-- PySR baseline requires `pysr` and a Julia runtime.
+## Architecture Snapshot
 
-## Security Note
+- `src/graph_invariant/cli.py`: orchestration and CLI entry points.
+- `src/graph_invariant/data.py`: graph generation and dataset splitting.
+- `src/graph_invariant/sandbox.py`: static checks + constrained execution pool.
+- `src/graph_invariant/scoring.py`: metrics, simplicity, novelty, total score.
+- `src/graph_invariant/benchmark.py`: deterministic multi-seed benchmark runner.
+- `src/graph_invariant/baselines/`: statistical and PySR baselines.
 
-`src/graph_invariant/sandbox.py` is a best-effort research sandbox. It uses static AST checks plus constrained execution with resource and timeout limits, but it is not a full security boundary. For production-grade untrusted execution, run candidates inside stronger OS/container isolation.
+## Artifacts
 
-If `persist_prompt_and_response_logs=true`, raw prompts and model responses are written to artifacts logs. Treat those logs as potentially sensitive data.
+Phase 1 run outputs:
+- `<artifacts_dir>/logs/events.jsonl`
+- `<artifacts_dir>/checkpoints/<experiment_id>/gen_<N>.json`
+- `<artifacts_dir>/phase1_summary.json`
+- `<artifacts_dir>/baselines_summary.json` (if `run_baselines=true`)
+- `<artifacts_dir>/report.md` (from `report` command)
+
+Benchmark outputs:
+- `<artifacts_dir>/benchmark_<timestamp>/benchmark_summary.json`
+- `<artifacts_dir>/benchmark_<timestamp>/benchmark_report.md`
+- `<artifacts_dir>/benchmark_<timestamp>/seed_<N>/...`
+
+## Documentation Map
+
+- `AGENTS.md`: contributor/agent workflow and repository etiquette.
+- `PRODUCT.md`: product goals and user-centric context.
+- `TECH.md`: technology choices and constraints.
+- `STRUCTURE.md`: repository layout and code organization.
+- `SPEC.md`: implementation spec (authoritative details).
+- `REVIEW.md`: resolved review findings.
+- `Research_Plan_Graph_Invariant_Discovery.md`: original proposal (historical context).
+
+## Security and Safety Notes
+
+- The sandbox is best-effort for research. It is not a production security boundary.
+- Candidate prompts/responses can be logged if enabled; treat logs as sensitive.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,69 @@
+# STRUCTURE.md
+
+## Repository Layout
+
+- `src/graph_invariant/`: implementation package
+- `tests/`: test suite
+- `.github/workflows/`: CI and automation workflows
+- `README.md`: human-oriented project entry point
+- `AGENTS.md`: agent/contributor operational rules
+- `PRODUCT.md`: product goals and user context
+- `TECH.md`: stack and constraints
+- `SPEC.md`: detailed implementation spec
+- `REVIEW.md`: historical technical review notes
+- `Research_Plan_Graph_Invariant_Discovery.md`: original proposal document
+
+## Source Package Structure
+
+- `src/graph_invariant/cli.py`
+  - CLI entry points and phase orchestration
+- `src/graph_invariant/config.py`
+  - validated runtime config dataclass (`Phase1Config`)
+- `src/graph_invariant/data.py`
+  - dataset generation for train/validation/test
+- `src/graph_invariant/sandbox.py`
+  - static checks and constrained candidate execution pool
+- `src/graph_invariant/scoring.py`
+  - metrics, simplicity, novelty, total score
+- `src/graph_invariant/evolution.py`
+  - island migration logic
+- `src/graph_invariant/known_invariants.py`
+  - known graph invariant calculations
+- `src/graph_invariant/logging_io.py`
+  - JSON/JSONL writes, checkpoint persistence helpers
+- `src/graph_invariant/benchmark.py`
+  - multi-seed benchmark orchestration
+- `src/graph_invariant/baselines/`
+  - baseline feature extraction and baseline runners
+
+## Naming and Organization Conventions
+
+- Test files: `tests/test_<module>.py`
+- Public functions and variables: `snake_case`
+- Classes/dataclasses: `PascalCase`
+- Keep module responsibilities narrow and explicit.
+
+## Import and Dependency Patterns
+
+- Import within package via relative imports (`from .module import ...`).
+- Keep cross-module coupling low:
+  - `cli.py` can orchestrate across modules.
+  - lower-level modules should avoid depending on CLI.
+- Add optional dependency handling in baseline modules where needed.
+
+## Artifact Structure (Runtime Output)
+
+- Phase 1:
+  - `<artifacts_dir>/logs/events.jsonl`
+  - `<artifacts_dir>/checkpoints/<experiment_id>/gen_<N>.json`
+  - `<artifacts_dir>/phase1_summary.json`
+  - `<artifacts_dir>/baselines_summary.json` (optional)
+- Benchmark:
+  - `<artifacts_dir>/benchmark_<timestamp>/benchmark_summary.json`
+  - `<artifacts_dir>/benchmark_<timestamp>/benchmark_report.md`
+  - `<artifacts_dir>/benchmark_<timestamp>/seed_<N>/...`
+
+## Historical Documents
+
+- `REVIEW.md` and `Research_Plan_Graph_Invariant_Discovery.md` are retained for historical context.
+- `SPEC.md` is the authoritative implementation reference.

--- a/TECH.md
+++ b/TECH.md
@@ -1,0 +1,53 @@
+# TECH.md
+
+## Technology Stack
+
+## Language and Runtime
+
+- Python 3.11+
+
+## Dependency and Environment Management
+
+- `uv` for dependency resolution, virtualenv management, and command execution
+- Project metadata and dependencies defined in `pyproject.toml`
+
+## Core Libraries
+
+- `networkx`: graph generation and graph statistics
+- `numpy`: vectorized numerical operations
+- `scipy`: statistical metrics (Spearman/Pearson)
+- `sympy`: symbolic simplification for simplicity scoring
+- `requests`: HTTP integration with Ollama API
+
+## Optional Libraries
+
+- `scikit-learn`: random-forest baseline
+- `pysr` + Julia runtime: symbolic regression baseline
+
+## Linting and Testing
+
+- `ruff` for linting and formatting checks
+- `pytest` for unit and integration-style module tests
+
+## CI
+
+- GitHub Actions workflows in `.github/workflows/`
+- Python CI gates:
+  - lint (`ruff check`)
+  - format check (`ruff format --check`)
+  - tests (`pytest`)
+
+## Technical Constraints
+
+- Sandbox evaluator is best-effort and not a full security boundary.
+- Ollama endpoint must be localhost unless `allow_remote_ollama=true`.
+- Artifact outputs are expected to be generated locally and kept out of Git.
+
+## Preferred Local Validation Command Set
+
+```bash
+uv sync --group dev
+uv run --group dev ruff check .
+uv run --group dev ruff format --check .
+uv run --group dev pytest -q
+```


### PR DESCRIPTION
## Summary
- refresh and expand `README.md` into a complete project guide (setup, usage, architecture, artifacts, docs map)
- replace `AGENTS.md` with explicit agent/developer operating guidance (commands, style, testing, branch/PR etiquette, gotchas)
- add missing key project docs: `PRODUCT.md`, `TECH.md`, and `STRUCTURE.md`
- update `.gitignore` for Python/uv caches, virtual envs, build outputs, and local artifact dirs
- clean local generated directories from workspace so the repo root stays tidy

## Why
This aligns the repository with a clear documentation hierarchy and keeps generated/local state out of version control while preserving historical research docs as reference material.

## Validation
- `uv run --group dev ruff check .` ✅
- `uv run --group dev ruff format --check .` ✅
- `uv run --group dev pytest -q` ✅
