### PR TITLE
Fix review findings and add MLX rerun estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![Python CI](https://github.com/yuyamukai/graph_invariant/actions/workflows/python-ci.yml/badge.svg)](https://github.com/yuyamukai/graph_invariant/actions/workflows/python-ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-LLM-driven graph invariant discovery for research workflows.
-This repository contains a Phase 1 implementation (data generation, candidate search/evaluation, novelty scoring, baselines, and reporting) with MAP-Elites diversity archive, bounds mode optimization, OOD validation, and self-correction.
+This repository currently contains two related research tracks:
+- `graph_invariant`: formula discovery over graph features (`src/graph_invariant/`).
+- `harmony`: theory discovery over typed knowledge graphs (`src/harmony/`), which matches the current manuscript in `paper/`.
 
 ## What This Project Does
 
@@ -176,8 +177,8 @@ Benchmark outputs:
 - Split policy: GitHub for lightweight paper package, Zenodo for raw experimental evidence.
 - Dataset DOI/record links and checksum manifests must be documented and cited from the paper.
 - Policy details: `docs/DATA_POLICY.md`
-- Current release handoff example: `docs/zenodo_release_neurips_day1_2026-02-22.md`
-- Current published dataset DOI: `10.5281/zenodo.18727765` (`https://zenodo.org/record/18727765`)
+- Graph-invariant release handoff example: `docs/zenodo_release_neurips_day1_2026-02-22.md`
+- Harmony release handoff example: `docs/zenodo_release_harmony_v1.md`
 
 ## Documentation Map
 
@@ -192,10 +193,10 @@ Benchmark outputs:
 
 ## Paper
 
-This repository accompanies the paper:
+The active manuscript source in `paper/` is:
 
-> **LLM-Driven Discovery of Interpretable Graph Invariants via Island-Model Evolution**
-> Yuya Mukai. 2026.
+> **Harmony-Driven Theory Discovery in Knowledge Graphs via LLM-Guided Island Search**
+> (anonymous submission format for double-blind review)
 
 The paper source is in `paper/` (NeurIPS format). Analysis scripts are in `analysis/`.
 Raw experiment datasets referenced by the paper should be archived on Zenodo and cited by DOI.
@@ -214,6 +215,14 @@ uv run python analysis/analyze_experiments.py \
   --output analysis/results/ \
   --appendix-tex-output paper/sections/appendix_tables_generated.tex
 uv run python analysis/generate_figures.py --data analysis/results/ --output paper/figures/
+```
+
+To audit bibliography sources via live DOI/URL checks:
+
+```bash
+uv run python scripts/audit_paper_sources.py \
+  --bib paper/references.bib \
+  --output docs/paper_source_audit.md
 ```
 
 ## License

--- a/docs/mlx_long_rerun_estimate_2026-03-04.md
+++ b/docs/mlx_long_rerun_estimate_2026-03-04.md
@@ -1,0 +1,40 @@
+# MLX Long-Rerun Estimate (2026-03-04)
+
+## Scope
+Estimate wall-clock time for the long rerun set after switching to Qwen 3.5 via MLX, assuming:
+- Harmony discovery reruns for 5 domains
+- 10-seed evaluation refresh
+- Block-A recomputation (multi-seed tables, stats, backtesting, downstream/frequency, Wikidata ablation, reproducibility table)
+- Single machine, same class of hardware documented in paper
+
+## Evidence Anchors
+- Factor decomposition runs (3 configs x 5 domains) with `mlx-community/Qwen3.5-35B-A3B-4bit` via `mlx_lm` are documented as ~2.5 hours total (`paper/sections/appendix.tex`).
+- The same appendix reports MLX throughput near ~46 tok/s (`paper/sections/appendix.tex`).
+- Block-A composition and defaults are documented in `scripts/run_block_a.py` and `scripts/run_multi_seed.py` (default 10 seeds).
+
+Derived unit estimate from the factor decomposition anchor:
+- 2.5h / 15 runs ~= 10 minutes per domain-run at this scale.
+
+## Revised Estimate (MLX Pipeline)
+For 5 domains x 10 seeds = 50 domain-runs:
+- Core reruns: ~50 x 10 min ~= 500 min ~= 8.3 h
+- Block-A postprocessing: ~40-50 min (including stats)
+- Analysis + figure + paper build: ~15-30 min
+
+Estimated wall-clock:
+- Best case: 8-10 h
+- Expected: 10-14 h
+- Worst case: 18-30 h (retry-heavy generations, intermittent hangs, manual recovery)
+
+## Notes on Uncertainty
+- Retry loops and proposal rejection dynamics can dominate tail latency.
+- If domain count increases from 5 to 7, scale core rerun time by ~1.4x.
+- If running with parallel workers >1, wall-clock may drop but contention can reduce per-worker throughput.
+
+## Pre-run Checkpointing Recommendation
+Before the full long rerun, run a short calibration slice (1 domain x 2 seeds) and compute observed min/domain-run.
+Then rescale:
+
+`Total hours ~= observed_min_per_domain_run * (num_domains * num_seeds) / 60 + overhead_hours`
+
+This gives a same-day correction before committing the full overnight budget.

--- a/docs/paper_source_audit.md
+++ b/docs/paper_source_audit.md
@@ -1,0 +1,33 @@
+# Paper Source Audit
+
+- Bib file: `paper/references.bib`
+- Entries audited: 20
+- DOI checks passed: 15
+- URL checks passed: 8
+
+| Key | Type | DOI | DOI Status | DOI Resolver | URL | URL Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| romeraparedes2024funsearch | article | 10.1038/s41586-023-06924-6 | OK | https://doi.org/10.1038/s41586-023-06924-6 |  | N/A |
+| cranmer2023pysr | misc | 10.48550/arXiv.2305.01582 | OK | https://doi.org/10.48550/arXiv.2305.01582 | https://arxiv.org/abs/2305.01582 | OK (200) |
+| mouret2015mapelites | misc | 10.48550/arXiv.1504.04909 | OK | https://doi.org/10.48550/arXiv.1504.04909 | https://arxiv.org/abs/1504.04909 | OK (200) |
+| whitley1997island | inbook | 10.1007/bfb0027170 | OK | https://doi.org/10.1007/bfb0027170 |  | N/A |
+| kipf2017gcn | misc | 10.48550/arXiv.1609.02907 | OK | https://doi.org/10.48550/arXiv.1609.02907 | https://arxiv.org/abs/1609.02907 | OK (200) |
+| xu2019gin | misc | 10.48550/arXiv.1810.00826 | OK | https://doi.org/10.48550/arXiv.1810.00826 | https://arxiv.org/abs/1810.00826 | OK (200) |
+| hagberg2008networkx | inproceedings | 10.25080/tcwv9851 | OK | https://doi.org/10.25080/tcwv9851 |  | N/A |
+| lehman2008novelty | inproceedings |  | N/A |  |  | N/A |
+| makke2024sr_survey | misc | 10.48550/arXiv.2211.10873 | OK | https://doi.org/10.48550/arXiv.2211.10873 | https://arxiv.org/abs/2211.10873 | OK (200) |
+| koza1992gp | book |  | N/A |  |  | N/A |
+| bordes2013transe | inproceedings |  | N/A |  | https://proceedings.neurips.cc/paper/2013/hash/1cecc7a77928ca8133fa24680a88d2f9-Abstract.html | OK (200) |
+| yang2015distmult | inproceedings | 10.48550/arXiv.1412.6575 | OK | https://doi.org/10.48550/arXiv.1412.6575 |  | N/A |
+| sun2019rotate | inproceedings | 10.48550/arXiv.1902.10197 | OK | https://doi.org/10.48550/arXiv.1902.10197 |  | N/A |
+| ji2021kgsurvey | article | 10.1109/TNNLS.2021.3070843 | OK | https://doi.org/10.1109/TNNLS.2021.3070843 |  | N/A |
+| baek2023kaping | inproceedings | 10.18653/v1/2023.findings-emnlp.580 | OK | https://doi.org/10.18653/v1/2023.findings-emnlp.580 |  | N/A |
+| sun2024thinkongraph | inproceedings | 10.48550/arXiv.2307.07697 | OK | https://doi.org/10.48550/arXiv.2307.07697 | https://arxiv.org/abs/2307.07697 | OK (200) |
+| jiang2023structgpt | inproceedings | 10.18653/v1/2023.emnlp-main.574 | OK | https://doi.org/10.18653/v1/2023.emnlp-main.574 |  | N/A |
+| trouillon2016complex | inproceedings |  | N/A |  |  | N/A |
+| anonymous2026harmony_dataset | dataset |  | N/A |  | https://zenodo.org/deposit/18795697 | OK (200) |
+| cliff1993dominance | article | 10.1037/0033-2909.114.3.494 | OK | https://doi.org/10.1037/0033-2909.114.3.494 |  | N/A |
+
+## Notes
+- DOI checks use `https://doi.org/<doi>` resolution with citation-style JSON accept header.
+- URL checks use `HEAD` then fallback `GET` on failure/non-2xx.

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -120,7 +120,7 @@
   volume    = {26},
   year      = {2013},
   publisher = {Curran Associates, Inc.},
-  DOI       = {10.5555/2999792.2999923}
+  url       = {https://proceedings.neurips.cc/paper/2013/hash/1cecc7a77928ca8133fa24680a88d2f9-Abstract.html}
 }
 
 % DistMult — arXiv DOI: 10.48550/arXiv.1412.6575 (ICLR 2015)
@@ -202,13 +202,12 @@
 }
 
 % ── Dataset citation (Zenodo) ─────────────────────────────────────────
-@dataset{anonymous2026graphinvariant_dataset,
+@dataset{anonymous2026harmony_dataset,
   author    = {Anonymous},
-  title     = {Graph Invariant Discovery: Raw Experimental Artifacts},
+  title     = {Harmony-Driven Theory Discovery: Experiment Artifacts (Anonymized Draft Record)},
   year      = {2026},
-  version   = {v2026.02.22-day1},
-  doi       = {10.5281/zenodo.18727765},
-  url       = {https://zenodo.org/record/18727765},
+  version   = {v1},
+  url       = {https://zenodo.org/deposit/18795697},
   publisher = {Zenodo}
 }
 

--- a/paper/sections/appendix.tex
+++ b/paper/sections/appendix.tex
@@ -167,7 +167,8 @@ Source code and all experimental artifacts are publicly available:
 \begin{itemize}[nosep]
   \item \textbf{Code repository}: anonymised for review; will be released upon
     acceptance.
-  \item \textbf{Data archive}: Zenodo (DOI: \texttt{10.5281/zenodo.18795697}),
+  \item \textbf{Data archive}: Zenodo anonymized draft record
+    (\texttt{https://zenodo.org/deposit/18795697}),
     containing all KG datasets, checkpoints, and generated proposals.
 \end{itemize}
 

--- a/paper/sections/checklist.tex
+++ b/paper/sections/checklist.tex
@@ -20,7 +20,7 @@
 \item {\bf Limitations}
     \item[] Question: Does the paper discuss the limitations of the work performed by the authors?
     \item[] Answer: \answerYes{}
-    \item[] Justification: Section~\ref{sec:discussion} contains a dedicated ``Limitations'' paragraph addressing four specific limitations: coarse relation vocabulary, manual expert rubric, equal edge-type weighting, and lack of statistical significance on most domains despite multi-seed evaluation.
+    \item[] Justification: Section~\ref{sec:discussion} contains a dedicated ``Limitations'' paragraph addressing concrete constraints including coarse relation vocabulary, metric-domain mismatch risk, evaluation circularity caveats, and lack of statistical significance on most domains despite multi-seed evaluation.
     \item[] Guidelines:
     \begin{itemize}
         \item The answer NA means that the paper has no limitation while the answer No means that the paper has limitations, but those are not discussed in the paper.

--- a/paper/sections/conclusion.tex
+++ b/paper/sections/conclusion.tex
@@ -14,15 +14,15 @@ with 10-seed cross-validation and four external KGE baselines reveals a nuanced
 picture.  The frequency heuristic achieves the highest Hits@10 overall,
 reflecting the strong inductive bias of edge-type distributions in small KGs.
 Among embedding-based methods, Harmony-guided proposals outperform
-DistMult-alone on Hits@10 and MRR in three of five domains, with the
+DistMult-alone on Hits@10 in three of five domains, with the
 strongest signal on the denser Wikidata Materials KG.  A regime
 characterisation analysis shows that Harmony's complementary value increases
 with graph density and edge-type diversity, suggesting that the framework is
 most beneficial for larger, structurally richer KGs.  Factor decomposition
-confirms that all three components---LLM proposer, Harmony scoring, and
-MAP-Elites diversity---contribute to proposal quality.  Backtesting against
-held-out edges provides external validity evidence independent of the training
-objective.
+shows strong contributions from Harmony scoring and MAP-Elites diversity, while
+further controlled experiments are needed to isolate the LLM proposer's
+independent contribution.  Backtesting against held-out edges serves as a
+conservative diagnostic independent of the training objective.
 
 Future work includes scaling to larger scientific KGs, extending the relation
 type vocabulary, integrating literature-retrieval-based plausibility scoring,

--- a/paper/sections/discussion.tex
+++ b/paper/sections/discussion.tex
@@ -47,8 +47,8 @@ where component weights are learned per domain via held-out validation
 performance.
 
 \paragraph{Frequency dominance and hybrid analysis.}
-The frequency heuristic achieves the highest Hits@10 across all five domains
-(Section~\ref{sec:freq-analysis}).  This is not surprising: in small KGs with
+The frequency heuristic is highly competitive and achieves the highest Hits@10
+on two of five domains (Section~\ref{sec:freq-analysis}).  This is not surprising: in small KGs with
 peaked edge-type distributions, predicting the dominant type is a strong
 baseline.  Rather than viewing this as a failure, we characterise the
 \emph{regime} where Harmony adds complementary value

--- a/paper/sections/experiments.tex
+++ b/paper/sections/experiments.tex
@@ -17,9 +17,9 @@ the shared seven-relation type vocabulary (Section~\ref{sec:schema}).
     gravity) and their theoretical inter-relations.
   \item \textbf{Materials science}: material properties, compounds, and
     structure--property relationships.
-  \item \textbf{Wikidata Physics}: 253 entities and 800+ edges extracted from
+  \item \textbf{Wikidata Physics}: 252 entities and 800+ edges extracted from
     Wikidata covering physical concepts, laws, and phenomena.
-  \item \textbf{Wikidata Materials}: 283 entities and 900+ edges extracted from
+  \item \textbf{Wikidata Materials}: 253 entities and 800+ edges extracted from
     Wikidata covering materials, properties, and applications.
 \end{itemize}
 
@@ -56,7 +56,8 @@ embedding dimension ($d = 50$), and training protocol:
   \item \textbf{TransE} \citep{bordes2013transe}: translational distance model.
   \item \textbf{RotatE} \citep{sun2019rotate}: rotation-based model in complex
     space.
-  \item \textbf{ComplEx}: complex-valued bilinear model with Hermitian product.
+  \item \textbf{ComplEx} \citep{trouillon2016complex}: complex-valued bilinear
+    model with Hermitian product.
 \end{enumerate}
 
 \noindent To break evaluation circularity (DistMult appears in both the Harmony

--- a/paper/sections/introduction.tex
+++ b/paper/sections/introduction.tex
@@ -51,6 +51,6 @@ concurrently with periodic migration to balance exploitation and exploration.
     stagnation-triggered constrained prompting (Section~\ref{sec:search}).
   \item Empirical evaluation on \textbf{five KG domains}---linear algebra,
     periodic table, astronomy, physics, and materials science---showing that
-    Harmony-guided proposals outperform frequency and random baselines on
-    Hits@10, with expert plausibility scores~$\geq 3.0$ (Section~\ref{sec:results}).
+    Harmony-guided proposals are competitive with embedding baselines and improve
+    over DistMult-alone on a subset of domains (Section~\ref{sec:results}).
 \end{enumerate}

--- a/paper/sections/method.tex
+++ b/paper/sections/method.tex
@@ -206,7 +206,8 @@ prompting.
 \paragraph{Migration.}
 Every $M = 10$ generations, the best proposal from each island migrates to the
 next island in a ring topology (island~$i \to$ island~$(i+1) \bmod 4$),
-replacing the worst candidate if the migrant has higher fitness.
+where it is prepended to the destination island's prompt-context buffer for the
+next generation.
 
 \paragraph{Generation loop.}
 Algorithm~\ref{alg:harmony} summarises a single generation.  The loop runs for
@@ -231,7 +232,7 @@ generation to enable resumption.
   \ENDIF
 \ENDFOR
 \IF{generation $\bmod\; M = 0$}
-  \STATE \textsc{Migrate}$(I_1, \ldots, I_4)$ \COMMENT{ring topology}
+  \STATE \textsc{MigrateTop1ToContext}$(I_1, \ldots, I_4)$ \COMMENT{ring topology}
 \ENDIF
 \end{algorithmic}
 \end{algorithm}

--- a/paper/sections/results.tex
+++ b/paper/sections/results.tex
@@ -228,10 +228,11 @@ Wikidata Mat.     & 0.00 & 0.00 & 0.00 & 0.00 & 0.00 & 0.00 \\
 \end{table}
 
 All precision and recall values are zero, indicating that LLM-generated
-proposals do not exactly recover held-out edges.  This is consistent with the
-design intent: the LLM generates \emph{novel} theoretical relationships rather
-than memorising existing edges.  Backtesting thus confirms that Harmony gains
-come from structural improvements to the KG rather than trivial edge recovery.
+proposals do not exactly recover held-out edges.  This is compatible with the
+design intent (proposals need not copy existing triples), but it is also
+compatible with low edge-recovery utility under this strict exact-match
+criterion.  We therefore treat backtesting as a negative-control diagnostic
+rather than evidence of novelty by itself.
 
 \subsection{Factor Decomposition}
 

--- a/scripts/audit_paper_sources.py
+++ b/scripts/audit_paper_sources.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Audit paper bibliography sources via live web checks.
+
+This script parses `paper/references.bib`, validates DOI resolution using
+`doi.org`, checks URL reachability, and writes a markdown audit report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+
+@dataclass(slots=True)
+class BibEntry:
+    key: str
+    entry_type: str
+    doi: str | None
+    url: str | None
+
+
+@dataclass(slots=True)
+class AuditRow:
+    key: str
+    entry_type: str
+    doi: str | None
+    doi_status: str
+    doi_title: str | None
+    doi_resolver: str | None
+    url: str | None
+    url_status: str
+
+
+ENTRY_HEADER_RE = re.compile(r"@(\w+)\s*\{\s*([^,]+),", re.IGNORECASE)
+FIELD_RE = re.compile(r"^\s*([A-Za-z_]+)\s*=\s*[{\"](.+?)[}\"]\s*,?\s*$")
+
+
+def _parse_bibtex(path: Path) -> list[BibEntry]:
+    entries: list[BibEntry] = []
+    entry_type: str | None = None
+    key: str | None = None
+    fields: dict[str, str] = {}
+    depth = 0
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("%"):
+            continue
+        if entry_type is None:
+            m = ENTRY_HEADER_RE.match(line)
+            if m:
+                entry_type = m.group(1).strip().lower()
+                key = m.group(2).strip()
+                fields = {}
+                depth = line.count("{") - line.count("}")
+            continue
+
+        depth += line.count("{") - line.count("}")
+        m = FIELD_RE.match(raw_line)
+        if m:
+            fields[m.group(1).strip().lower()] = m.group(2).strip()
+        if depth <= 0:
+            entries.append(
+                BibEntry(
+                    key=key or "unknown",
+                    entry_type=entry_type,
+                    doi=fields.get("doi"),
+                    url=fields.get("url"),
+                )
+            )
+            entry_type = None
+            key = None
+            fields = {}
+            depth = 0
+    return entries
+
+
+def _fetch_doi_metadata(doi: str, timeout_sec: float) -> tuple[str, str | None, str | None]:
+    resolver = f"https://doi.org/{doi}"
+    headers = {"Accept": "application/vnd.citationstyles.csl+json"}
+    try:
+        resp = requests.get(resolver, headers=headers, timeout=timeout_sec, allow_redirects=True)
+        if resp.status_code != 200:
+            return f"HTTP {resp.status_code}", None, resolver
+        payload = resp.json()
+        title = payload.get("title")
+        if isinstance(title, list):
+            title = title[0] if title else None
+        if title is not None and not isinstance(title, str):
+            title = str(title)
+        return "OK", title, resolver
+    except requests.RequestException as exc:
+        return f"ERROR {type(exc).__name__}", None, resolver
+    except ValueError:
+        # Some resolvers may return non-JSON HTML pages even with Accept header.
+        return "OK (non-JSON)", None, resolver
+
+
+def _check_url(url: str, timeout_sec: float) -> str:
+    try:
+        head = requests.head(url, timeout=timeout_sec, allow_redirects=True)
+        if head.status_code < 400:
+            return f"OK ({head.status_code})"
+        # fallback to GET in case HEAD is unsupported
+        get = requests.get(url, timeout=timeout_sec, allow_redirects=True)
+        return f"OK ({get.status_code})" if get.status_code < 400 else f"HTTP {get.status_code}"
+    except requests.RequestException as exc:
+        return f"ERROR {type(exc).__name__}"
+
+
+def _audit_entries(entries: Iterable[BibEntry], timeout_sec: float) -> list[AuditRow]:
+    rows: list[AuditRow] = []
+    for entry in entries:
+        doi_status = "N/A"
+        doi_title = None
+        doi_resolver = None
+        if entry.doi:
+            doi_status, doi_title, doi_resolver = _fetch_doi_metadata(entry.doi, timeout_sec)
+        url_status = "N/A"
+        if entry.url:
+            url_status = _check_url(entry.url, timeout_sec)
+        rows.append(
+            AuditRow(
+                key=entry.key,
+                entry_type=entry.entry_type,
+                doi=entry.doi,
+                doi_status=doi_status,
+                doi_title=doi_title,
+                doi_resolver=doi_resolver,
+                url=entry.url,
+                url_status=url_status,
+            )
+        )
+    return rows
+
+
+def _render_report(rows: list[AuditRow], bib_path: Path) -> str:
+    total = len(rows)
+    doi_ok = sum(1 for r in rows if r.doi and r.doi_status.startswith("OK"))
+    url_ok = sum(1 for r in rows if r.url and r.url_status.startswith("OK"))
+    lines = [
+        "# Paper Source Audit",
+        "",
+        f"- Bib file: `{bib_path}`",
+        f"- Entries audited: {total}",
+        f"- DOI checks passed: {doi_ok}",
+        f"- URL checks passed: {url_ok}",
+        "",
+        "| Key | Type | DOI | DOI Status | DOI Resolver | URL | URL Status |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for r in rows:
+        doi = r.doi or ""
+        resolver = r.doi_resolver or ""
+        url = r.url or ""
+        lines.append(
+            f"| {r.key} | {r.entry_type} | {doi} | {r.doi_status} | "
+            f"{resolver} | {url} | {r.url_status} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "- DOI checks use `https://doi.org/<doi>` resolution with "
+            "citation-style JSON accept header.",
+            "- URL checks use `HEAD` then fallback `GET` on failure/non-2xx.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit paper bibliography sources via web checks.")
+    parser.add_argument(
+        "--bib",
+        type=Path,
+        default=Path("paper/references.bib"),
+        help="Path to BibTeX file (default: paper/references.bib)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("docs/paper_source_audit.md"),
+        help="Path to markdown output (default: docs/paper_source_audit.md)",
+    )
+    parser.add_argument(
+        "--timeout-sec",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds for each check (default: 10.0)",
+    )
+    args = parser.parse_args()
+
+    entries = _parse_bibtex(args.bib)
+    rows = _audit_entries(entries, timeout_sec=args.timeout_sec)
+    report = _render_report(rows, bib_path=args.bib)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report, encoding="utf-8")
+    print(f"Wrote audit report: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_paper_sources.py
+++ b/scripts/audit_paper_sources.py
@@ -8,10 +8,13 @@ This script parses `paper/references.bib`, validates DOI resolution using
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import re
+import socket
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urljoin, urlsplit
 
 import requests
 
@@ -37,47 +40,218 @@ class AuditRow:
 
 
 ENTRY_HEADER_RE = re.compile(r"@(\w+)\s*\{\s*([^,]+),", re.IGNORECASE)
-FIELD_RE = re.compile(r"^\s*([A-Za-z_]+)\s*=\s*[{\"](.+?)[}\"]\s*,?\s*$")
+
+_FORBIDDEN_LOCAL_HOSTNAMES = {"localhost", "localhost.localdomain"}
+_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+
+
+def _read_braced_value(text: str, pos: int) -> tuple[str, int]:
+    depth = 1
+    i = pos + 1
+    out: list[str] = []
+    while i < len(text):
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "}":
+            depth -= 1
+            if depth == 0:
+                return "".join(out), i + 1
+            out.append(ch)
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out), i
+
+
+def _read_quoted_value(text: str, pos: int) -> tuple[str, int]:
+    i = pos + 1
+    out: list[str] = []
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text):
+            out.append(text[i + 1])
+            i += 2
+            continue
+        if ch == '"':
+            return "".join(out), i + 1
+        out.append(ch)
+        i += 1
+    return "".join(out), i
+
+
+def _read_plain_value(text: str, pos: int) -> tuple[str, int]:
+    i = pos
+    while i < len(text) and text[i] not in ",\n\r":
+        i += 1
+    return text[pos:i], i
+
+
+def _parse_entry_fields(entry_text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    i = 0
+    n = len(entry_text)
+    while i < n:
+        while i < n and entry_text[i] in " \t\r\n,":
+            i += 1
+        if i >= n:
+            break
+        key_start = i
+        while i < n and (entry_text[i].isalnum() or entry_text[i] in "_-"):
+            i += 1
+        key = entry_text[key_start:i].strip().lower()
+        if not key:
+            while i < n and entry_text[i] not in "\n\r":
+                i += 1
+            continue
+        while i < n and entry_text[i].isspace():
+            i += 1
+        if i >= n or entry_text[i] != "=":
+            while i < n and entry_text[i] not in ",\n\r":
+                i += 1
+            continue
+        i += 1
+        while i < n and entry_text[i].isspace():
+            i += 1
+        if i >= n:
+            break
+        if entry_text[i] == "{":
+            value, i = _read_braced_value(entry_text, i)
+        elif entry_text[i] == '"':
+            value, i = _read_quoted_value(entry_text, i)
+        else:
+            value, i = _read_plain_value(entry_text, i)
+        normalized = " ".join(value.split()).strip()
+        fields[key] = normalized
+        while i < n and entry_text[i].isspace():
+            i += 1
+        if i < n and entry_text[i] == ",":
+            i += 1
+    return fields
 
 
 def _parse_bibtex(path: Path) -> list[BibEntry]:
     entries: list[BibEntry] = []
-    entry_type: str | None = None
-    key: str | None = None
-    fields: dict[str, str] = {}
-    depth = 0
-
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("%"):
-            continue
-        if entry_type is None:
-            m = ENTRY_HEADER_RE.match(line)
-            if m:
-                entry_type = m.group(1).strip().lower()
-                key = m.group(2).strip()
-                fields = {}
-                depth = line.count("{") - line.count("}")
-            continue
-
-        depth += line.count("{") - line.count("}")
-        m = FIELD_RE.match(raw_line)
-        if m:
-            fields[m.group(1).strip().lower()] = m.group(2).strip()
-        if depth <= 0:
-            entries.append(
-                BibEntry(
-                    key=key or "unknown",
-                    entry_type=entry_type,
-                    doi=fields.get("doi"),
-                    url=fields.get("url"),
-                )
+    text = path.read_text(encoding="utf-8")
+    pos = 0
+    while True:
+        match = ENTRY_HEADER_RE.search(text, pos)
+        if match is None:
+            break
+        entry_type = match.group(1).strip().lower()
+        key = match.group(2).strip() or "unknown"
+        i = match.end()
+        depth = 1
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        entry_text = text[match.end() : max(match.end(), i - 1)]
+        fields = _parse_entry_fields(entry_text)
+        entries.append(
+            BibEntry(
+                key=key,
+                entry_type=entry_type,
+                doi=fields.get("doi"),
+                url=fields.get("url"),
             )
-            entry_type = None
-            key = None
-            fields = {}
-            depth = 0
+        )
+        pos = i
     return entries
+
+
+def _forbidden_ip_reason(ip_addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+    if ip_addr.is_private:
+        return "private address"
+    if ip_addr.is_loopback:
+        return "loopback address"
+    if ip_addr.is_link_local:
+        return "link-local address"
+    if ip_addr.is_multicast:
+        return "multicast address"
+    if ip_addr.is_reserved:
+        return "reserved address"
+    if ip_addr.is_unspecified:
+        return "unspecified address"
+    return None
+
+
+def _resolve_host_ips(host: str) -> tuple[list[str], str | None]:
+    try:
+        ip_literal = ipaddress.ip_address(host)
+        return [str(ip_literal)], None
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        return [], f"host resolution failed ({type(exc).__name__})"
+    ips = sorted({info[4][0] for info in infos if info and info[4]})
+    if not ips:
+        return [], "host resolution returned no addresses"
+    return ips, None
+
+
+def _validate_public_http_url(raw_url: str) -> tuple[str | None, str | None]:
+    url = raw_url.strip()
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return None, "invalid URL"
+    if parsed.scheme not in {"http", "https"}:
+        return None, "URL scheme must be http/https"
+    if parsed.username or parsed.password:
+        return None, "URL must not include credentials"
+    host = parsed.hostname
+    if host is None:
+        return None, "URL host is missing"
+    lowered_host = host.lower()
+    if lowered_host in _FORBIDDEN_LOCAL_HOSTNAMES:
+        return None, "URL host resolves to local machine"
+    try:
+        _ = parsed.port
+    except ValueError:
+        return None, "invalid URL port"
+    ips, resolve_error = _resolve_host_ips(host)
+    if resolve_error is not None:
+        return None, resolve_error
+    for ip_text in ips:
+        try:
+            ip_addr = ipaddress.ip_address(ip_text)
+        except ValueError:
+            return None, f"invalid resolved IP {ip_text}"
+        reason = _forbidden_ip_reason(ip_addr)
+        if reason is not None:
+            return None, f"URL points to forbidden {reason} ({ip_text})"
+    return url, None
+
+
+def _request_with_validated_redirects(
+    method: str,
+    start_url: str,
+    timeout_sec: float,
+    max_redirects: int = 5,
+) -> tuple[requests.Response | None, str | None]:
+    current = start_url
+    for _ in range(max_redirects + 1):
+        resp = requests.request(method, current, timeout=timeout_sec, allow_redirects=False)
+        if resp.status_code not in _REDIRECT_STATUS_CODES:
+            return resp, None
+        location = resp.headers.get("Location")
+        if not location:
+            return resp, None
+        next_url = urljoin(current, location)
+        _, err = _validate_public_http_url(next_url)
+        if err is not None:
+            return None, f"BLOCKED redirect target: {err}"
+        current = next_url
+    return None, "ERROR TooManyRedirects"
 
 
 def _fetch_doi_metadata(doi: str, timeout_sec: float) -> tuple[str, str | None, str | None]:
@@ -102,12 +276,30 @@ def _fetch_doi_metadata(doi: str, timeout_sec: float) -> tuple[str, str | None, 
 
 
 def _check_url(url: str, timeout_sec: float) -> str:
+    safe_url, validation_error = _validate_public_http_url(url)
+    if validation_error is not None:
+        return f"BLOCKED {validation_error}"
+    assert safe_url is not None
     try:
-        head = requests.head(url, timeout=timeout_sec, allow_redirects=True)
+        head, head_error = _request_with_validated_redirects(
+            "HEAD",
+            safe_url,
+            timeout_sec=timeout_sec,
+        )
+        if head_error is not None:
+            return head_error
+        assert head is not None
         if head.status_code < 400:
             return f"OK ({head.status_code})"
         # fallback to GET in case HEAD is unsupported
-        get = requests.get(url, timeout=timeout_sec, allow_redirects=True)
+        get, get_error = _request_with_validated_redirects(
+            "GET",
+            safe_url,
+            timeout_sec=timeout_sec,
+        )
+        if get_error is not None:
+            return get_error
+        assert get is not None
         return f"OK ({get.status_code})" if get.status_code < 400 else f"HTTP {get.status_code}"
     except requests.RequestException as exc:
         return f"ERROR {type(exc).__name__}"

--- a/src/graph_invariant/llm_ollama.py
+++ b/src/graph_invariant/llm_ollama.py
@@ -252,6 +252,8 @@ def validate_ollama_url(generate_url: str, allow_remote: bool) -> tuple[str, dic
         raise ValueError("ollama_url must use http or https")
     if not parsed.netloc:
         raise ValueError("ollama_url must include a host")
+    if parsed.username or parsed.password:
+        raise ValueError("ollama_url must not include username/password credentials")
 
     hostname = parsed.hostname
     port = parsed.port
@@ -284,7 +286,11 @@ def validate_ollama_url(generate_url: str, allow_remote: bool) -> tuple[str, dic
         if not ip.is_loopback:
             raise ValueError("ollama_url must target localhost unless allow_remote_ollama is true")
     else:
-        # Remote allowed: Block dangerous IPs
+        # Remote allowed: still block non-routable/sensitive address classes.
+        if ip.is_private:
+            raise ValueError(f"ollama_url targets private address {ip_str}, which is forbidden")
+        if ip.is_unspecified:
+            raise ValueError(f"ollama_url targets unspecified address {ip_str}, which is forbidden")
         if ip.is_link_local:
             raise ValueError(f"ollama_url targets link-local address {ip_str}, which is forbidden")
         if ip.is_multicast:

--- a/src/harmony/config.py
+++ b/src/harmony/config.py
@@ -30,6 +30,8 @@ class HarmonyConfig:
     gamma: float = 0.25  # symmetry
     delta: float = 0.25  # generativity
     epsilon: float = 0.0  # frequency (hybrid; 0.0 = pure Harmony)
+    lambda_cost: float = 0.1
+    cost_mode: str = "normalized_mutation_size"
     # Dataset split
     hidden_ratio: float = 0.1
     # Proposal engine
@@ -70,10 +72,16 @@ class HarmonyConfig:
             raise ValueError("stagnation_trigger_generations must be >= 1")
         if self.constrained_recovery_generations < 1:
             raise ValueError("constrained_recovery_generations must be >= 1")
+        if self.migration_interval < 1:
+            raise ValueError("migration_interval must be >= 1")
         if self.llm_timeout_sec <= 0.0:
             raise ValueError("llm_timeout_sec must be > 0.0")
         if self.self_correction_max_retries < 0:
             raise ValueError("self_correction_max_retries must be >= 0")
+        if self.lambda_cost < 0.0:
+            raise ValueError("lambda_cost must be >= 0.0")
+        if self.cost_mode not in ("normalized_mutation_size", "none"):
+            raise ValueError("cost_mode must be 'normalized_mutation_size' or 'none'")
         min_bins = 1 if self.greedy else 2
         if self.map_elites_bins < min_bins:
             raise ValueError(f"map_elites_bins must be >= {min_bins}")

--- a/src/harmony/harmony_loop.py
+++ b/src/harmony/harmony_loop.py
@@ -63,6 +63,24 @@ def _init_island_state(state: HarmonySearchState, n_islands: int) -> None:
             state.islands[i] = []
 
 
+def _migrate_ring_top1(state: HarmonySearchState) -> None:
+    """Migrate top-1 proposal in ring topology: island i -> (i+1) mod N."""
+    island_ids = sorted(state.islands.keys())
+    if len(island_ids) < 2:
+        return
+    migrants: dict[int, dict[str, Any] | None] = {}
+    for island_id in island_ids:
+        proposals = state.islands.get(island_id, [])
+        migrants[island_id] = proposals[0] if proposals else None
+    for island_id in island_ids:
+        src = island_ids[(island_ids.index(island_id) - 1) % len(island_ids)]
+        migrant = migrants.get(src)
+        if migrant is None:
+            continue
+        existing = state.islands.get(island_id, [])
+        state.islands[island_id] = [migrant] + existing[:4]
+
+
 # ---------------------------------------------------------------------------
 # Island generation
 # ---------------------------------------------------------------------------
@@ -274,6 +292,14 @@ def run_harmony_loop(
             seed=cfg.seed,
             archive_bins=cfg.map_elites_bins,
             accept_all_valid=cfg.accept_all_valid,
+            archive=archive,
+            lambda_cost=cfg.lambda_cost,
+            cost_mode=cfg.cost_mode,
+            alpha=cfg.alpha,
+            beta=cfg.beta,
+            gamma=cfg.gamma,
+            delta=cfg.delta,
+            epsilon=cfg.epsilon,
         )
 
         # --- Update island context with best proposals ---
@@ -288,6 +314,18 @@ def run_harmony_loop(
                 target_island = rank % n_islands
                 existing = state.islands[target_island]
                 state.islands[target_island] = [result.proposal.to_dict()] + existing[:4]
+
+        if cfg.migration_interval > 0 and (state.generation + 1) % cfg.migration_interval == 0:
+            _migrate_ring_top1(state)
+            _append_jsonl(
+                {
+                    "event": "migration",
+                    "experiment_id": state.experiment_id,
+                    "generation": state.generation + 1,
+                    "migration_interval": cfg.migration_interval,
+                },
+                log_path,
+            )
 
         # --- Update archive checkpoint ---
         state.archive = serialize_archive(pipeline_result.archive)

--- a/src/harmony/proposals/pipeline.py
+++ b/src/harmony/proposals/pipeline.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import copy
 import logging
 from dataclasses import dataclass
 
 from harmony.map_elites import HarmonyMapElites, try_insert
-from harmony.metric.harmony import harmony_score
+from harmony.metric.harmony import value_of
 from harmony.proposals.types import Proposal, ProposalType, ValidationResult
 from harmony.proposals.validator import validate
 from harmony.types import EdgeType, Entity, KnowledgeGraph, TypedEdge
@@ -35,8 +34,12 @@ class PipelineResult:
 
 
 def _apply_mutation(kg: KnowledgeGraph, proposal: Proposal) -> KnowledgeGraph:
-    """Return a deep copy of kg with the proposal mutation applied."""
-    kg_copy = copy.deepcopy(kg)
+    """Return a copy of kg with the proposal mutation applied."""
+    kg_copy = KnowledgeGraph(
+        domain=kg.domain,
+        entities=dict(kg.entities),
+        edges=list(kg.edges),
+    )
 
     if proposal.proposal_type == ProposalType.ADD_EDGE:
         edge = TypedEdge(
@@ -71,16 +74,62 @@ def _apply_mutation(kg: KnowledgeGraph, proposal: Proposal) -> KnowledgeGraph:
     return kg_copy
 
 
+def _grounding_violations(proposal: Proposal, kg: KnowledgeGraph) -> list[str]:
+    """Return KG-grounding validation violations for a schema-valid proposal."""
+    violations: list[str] = []
+    if proposal.kg_domain != kg.domain:
+        violations.append(
+            f"'kg_domain' must match current KG domain '{kg.domain}', got '{proposal.kg_domain}'"
+        )
+
+    if proposal.proposal_type in (ProposalType.ADD_EDGE, ProposalType.REMOVE_EDGE):
+        if proposal.source_entity not in kg.entities:
+            violations.append(
+                f"unknown source_entity '{proposal.source_entity}' for domain '{kg.domain}'"
+            )
+        if proposal.target_entity not in kg.entities:
+            violations.append(
+                f"unknown target_entity '{proposal.target_entity}' for domain '{kg.domain}'"
+            )
+    elif proposal.proposal_type == ProposalType.ADD_ENTITY:
+        if proposal.entity_id in kg.entities:
+            violations.append(
+                f"entity_id '{proposal.entity_id}' already exists in domain '{kg.domain}'"
+            )
+    elif proposal.proposal_type == ProposalType.REMOVE_ENTITY:
+        if proposal.entity_id not in kg.entities:
+            violations.append(f"unknown entity_id '{proposal.entity_id}' for domain '{kg.domain}'")
+    return violations
+
+
+def _proposal_cost(kg: KnowledgeGraph, proposal: Proposal, cost_mode: str) -> float:
+    if cost_mode == "none":
+        return 0.0
+    if cost_mode != "normalized_mutation_size":
+        raise ValueError("cost_mode must be 'normalized_mutation_size' or 'none'")
+    if proposal.proposal_type in (ProposalType.ADD_EDGE, ProposalType.REMOVE_EDGE):
+        return 1.0 / max(1, kg.num_edges)
+    return 1.0 / max(1, kg.num_entities)
+
+
 def run_pipeline(
     kg: KnowledgeGraph,
     proposals: list[Proposal],
     seed: int = 42,
     archive_bins: int = 5,
     accept_all_valid: bool = False,
+    archive: HarmonyMapElites | None = None,
+    lambda_cost: float = 0.1,
+    cost_mode: str = "normalized_mutation_size",
+    alpha: float = 0.25,
+    beta: float = 0.25,
+    gamma: float = 0.25,
+    delta: float = 0.25,
+    epsilon: float = 0.0,
 ) -> PipelineResult:
     """Validate → apply mutation → score → archive each proposal.
 
-    harmony_gain = harmony_score(kg_after) − harmony_score(kg_before)
+    harmony_gain = value_of(kg_before, kg_after)
     simplicity   = 1 / (1 + len(claim) + len(justification))  ∈ (0, 1]
 
     Descriptor (simplicity, gain_norm) is inserted into the MAP-Elites archive,
@@ -93,25 +142,36 @@ def run_pipeline(
     """
     if not proposals:
         logger.info("Pipeline valid_rate=0.000 (0/0)")
-        empty_archive = HarmonyMapElites(num_bins=archive_bins)
-        return PipelineResult(results=[], valid_rate=0.0, archive=empty_archive)
+        current_archive = (
+            archive if archive is not None else HarmonyMapElites(num_bins=archive_bins)
+        )
+        return PipelineResult(results=[], valid_rate=0.0, archive=current_archive)
 
-    archive = HarmonyMapElites(num_bins=archive_bins)
-
-    if not accept_all_valid:
-        h_before = harmony_score(kg, seed=seed)
+    archive_obj = archive if archive is not None else HarmonyMapElites(num_bins=archive_bins)
 
     # First pass: validate and compute gains
     results: list[ProposalResult] = []
     valid_count = 0
 
     for proposal in proposals:
-        validation = validate(proposal)
-        if not validation.is_valid:
+        schema_validation = validate(proposal)
+        if not schema_validation.is_valid:
             results.append(
                 ProposalResult(
                     proposal=proposal,
-                    validation=validation,
+                    validation=schema_validation,
+                    harmony_gain=None,
+                    inserted_to_archive=False,
+                )
+            )
+            continue
+
+        grounding_violations = _grounding_violations(proposal, kg)
+        if grounding_violations:
+            results.append(
+                ProposalResult(
+                    proposal=proposal,
+                    validation=ValidationResult(is_valid=False, violations=grounding_violations),
                     harmony_gain=None,
                     inserted_to_archive=False,
                 )
@@ -125,7 +185,18 @@ def run_pipeline(
         else:
             try:
                 kg_after = _apply_mutation(kg, proposal)
-                gain = harmony_score(kg_after, seed=seed) - h_before
+                gain = value_of(
+                    kg_before=kg,
+                    kg_after=kg_after,
+                    alpha=alpha,
+                    beta=beta,
+                    gamma=gamma,
+                    delta=delta,
+                    epsilon=epsilon,
+                    lambda_cost=lambda_cost,
+                    cost=_proposal_cost(kg, proposal, cost_mode),
+                    seed=seed,
+                )
             except Exception as e:
                 logger.warning("Error processing valid proposal %s: %s", proposal.id, e)
                 gain = None
@@ -133,7 +204,7 @@ def run_pipeline(
         results.append(
             ProposalResult(
                 proposal=proposal,
-                validation=validation,
+                validation=ValidationResult(is_valid=True, violations=[]),
                 harmony_gain=gain,
                 inserted_to_archive=False,
             )
@@ -156,10 +227,10 @@ def run_pipeline(
             simplicity = 1.0 / (1.0 + claim_len)
             gain_norm = (result.harmony_gain - gain_min) / gain_range
             result.inserted_to_archive = try_insert(
-                archive,
+                archive_obj,
                 result.proposal,
                 fitness_signal=result.harmony_gain,
                 descriptor=(simplicity, gain_norm),
             )
 
-    return PipelineResult(results=results, valid_rate=valid_rate, archive=archive)
+    return PipelineResult(results=results, valid_rate=valid_rate, archive=archive_obj)

--- a/tests/harmony/test_factor_decomposition.py
+++ b/tests/harmony/test_factor_decomposition.py
@@ -117,16 +117,16 @@ class TestPipelineAcceptAllValid:
     """TDD: verify accept_all_valid skips harmony_score in pipeline."""
 
     def test_pipeline_accept_all_valid_skips_scoring(self, monkeypatch):
-        """When accept_all_valid=True, harmony_score is never called."""
+        """When accept_all_valid=True, value_of is never called."""
         from harmony.proposals import pipeline as pipeline_mod
         from harmony.proposals.pipeline import run_pipeline
         from harmony.proposals.types import Proposal, ProposalType
 
-        # If harmony_score is called, this will blow up
+        # If value_of is called, this will blow up.
         def _boom(*args, **kwargs):
-            raise AssertionError("harmony_score should not be called")
+            raise AssertionError("value_of should not be called")
 
-        monkeypatch.setattr(pipeline_mod, "harmony_score", _boom)
+        monkeypatch.setattr(pipeline_mod, "value_of", _boom)
 
         kg = _make_test_kg()
         proposal = Proposal(
@@ -134,7 +134,7 @@ class TestPipelineAcceptAllValid:
             proposal_type=ProposalType.ADD_EDGE,
             claim="Test claim for accept_all_valid pipeline.",
             justification="Testing that scoring is skipped entirely.",
-            falsification_condition="If harmony_score is called, the test fails.",
+            falsification_condition="If value_of is called, the test fails.",
             kg_domain="test",
             source_entity="e0",
             target_entity="e5",

--- a/tests/harmony/test_harmony_loop.py
+++ b/tests/harmony/test_harmony_loop.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 from harmony.config import HarmonyConfig
 from harmony.datasets.linear_algebra import build_linear_algebra_kg
 from harmony.harmony_loop import run_harmony_loop
-from harmony.state import HarmonySearchState
+from harmony.state import HarmonySearchState, save_state
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -247,3 +247,40 @@ class TestResume:
             state2 = run_harmony_loop(cfg2, kg, output_dir=tmp_path, resume=checkpoint_path)
 
         assert state2.generation == 5
+
+
+class TestMigration:
+    def test_migration_interval_moves_top_proposals(self, tmp_path: Path):
+        cfg = _make_cfg(
+            max_generations=1,
+            population_size=1,
+            migration_interval=1,
+            early_stop_patience=10,
+        )
+        kg = build_linear_algebra_kg()
+        state = HarmonySearchState(
+            experiment_id="resume-migration",
+            generation=0,
+            islands={
+                0: [{"id": "i0"}],
+                1: [{"id": "i1"}],
+                2: [{"id": "i2"}],
+                3: [{"id": "i3"}],
+            },
+            rng_seed=42,
+            island_prompt_mode={0: "free", 1: "free", 2: "free", 3: "free"},
+            island_stagnation={0: 0, 1: 0, 2: 0, 3: 0},
+            island_recent_failures={0: [], 1: [], 2: [], 3: []},
+            island_constrained_generations={0: 0, 1: 0, 2: 0, 3: 0},
+        )
+        checkpoint = tmp_path / "checkpoint.json"
+        save_state(state, checkpoint)
+
+        with patch("harmony.harmony_loop._run_island_generation") as mock_island_gen:
+            mock_island_gen.return_value = ([], 0)
+            migrated = run_harmony_loop(cfg, kg, output_dir=tmp_path, resume=str(checkpoint))
+
+        assert migrated.islands[0][0]["id"] == "i3"
+        assert migrated.islands[1][0]["id"] == "i0"
+        assert migrated.islands[2][0]["id"] == "i1"
+        assert migrated.islands[3][0]["id"] == "i2"

--- a/tests/harmony/test_proposal_pipeline.py
+++ b/tests/harmony/test_proposal_pipeline.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pytest
 
 from harmony.datasets.linear_algebra import build_linear_algebra_kg
+from harmony.map_elites import HarmonyMapElites
 from harmony.proposals.pipeline import run_pipeline
 from harmony.proposals.types import Proposal, ProposalType
 
@@ -109,6 +110,23 @@ class TestValidRate:
         assert result.valid_rate == pytest.approx(0.0)
         assert result.results == []
 
+    def test_grounding_invalid_not_counted_as_valid(self, kg):
+        p = Proposal(
+            id="unknown-entities",
+            proposal_type=ProposalType.ADD_EDGE,
+            claim="Unknown entities should be rejected by grounding checks.",
+            justification="Schema can pass while grounding must still fail.",
+            falsification_condition="If unknown entities are accepted as valid.",
+            kg_domain="linear_algebra",
+            source_entity="does_not_exist",
+            target_entity="also_missing",
+            edge_type="DEPENDS_ON",
+        )
+        result = run_pipeline(kg, [p], seed=42)
+        assert result.valid_rate == pytest.approx(0.0)
+        assert result.results[0].validation.is_valid is False
+        assert any("unknown source_entity" in v for v in result.results[0].validation.violations)
+
 
 class TestDeterminism:
     def test_pipeline_deterministic(self, kg):
@@ -193,3 +211,12 @@ class TestArchive:
         result = run_pipeline(kg, proposals, seed=42)
         assert result.archive is not None
         assert hasattr(result.archive, "cells")
+
+    def test_pipeline_reuses_existing_archive(self, kg):
+        proposals = [_make_valid_add_entity_proposal("p1")]
+        archive = HarmonyMapElites(num_bins=5)
+        result1 = run_pipeline(kg, proposals, seed=42, archive=archive)
+        coverage1 = len(result1.archive.cells)
+        result2 = run_pipeline(kg, proposals, seed=42, archive=result1.archive)
+        coverage2 = len(result2.archive.cells)
+        assert coverage2 >= coverage1

--- a/tests/test_audit_paper_sources.py
+++ b/tests/test_audit_paper_sources.py
@@ -1,0 +1,71 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def audit_module():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "audit_paper_sources.py"
+    spec = importlib.util.spec_from_file_location("audit_paper_sources", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load audit_paper_sources module spec")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_url_blocks_link_local_without_network(audit_module, monkeypatch):
+    def _no_network(*_args, **_kwargs):
+        raise AssertionError("network call should not be attempted for blocked URLs")
+
+    monkeypatch.setattr(audit_module.requests, "request", _no_network)
+
+    status = audit_module._check_url("http://169.254.169.254/latest/meta-data", timeout_sec=1.0)
+    assert status.startswith("BLOCKED")
+
+
+def test_parse_bibtex_multiline_fields(audit_module, tmp_path):
+    bib = tmp_path / "sample.bib"
+    bib.write_text(
+        """
+@article{foo2026,
+  title = {A long title that spans
+    multiple lines with {nested} braces},
+  doi = {10.1000/example},
+  url = {https://example.com/path?x=1&y=2}
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries = audit_module._parse_bibtex(bib)
+    assert len(entries) == 1
+    assert entries[0].key == "foo2026"
+    assert entries[0].entry_type == "article"
+    assert entries[0].doi == "10.1000/example"
+    assert entries[0].url == "https://example.com/path?x=1&y=2"
+
+
+def test_parse_bibtex_multiline_quoted_fields(audit_module, tmp_path):
+    bib = tmp_path / "quoted.bib"
+    bib.write_text(
+        """
+@inproceedings{bar2026,
+  title = "Quoted title on
+    two lines",
+  url = "https://example.org/ok"
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries = audit_module._parse_bibtex(bib)
+    assert len(entries) == 1
+    assert entries[0].key == "bar2026"
+    assert entries[0].entry_type == "inproceedings"
+    assert entries[0].url == "https://example.org/ok"

--- a/tests/test_security_ollama.py
+++ b/tests/test_security_ollama.py
@@ -40,7 +40,7 @@ def test_validate_ollama_url_public_ip_allow_remote_true():
 def test_validate_ollama_url_metadata_ip_blocked():
     # Test allow_remote=True with metadata IP (blocked)
     # 169.254.169.254 is link-local
-    with pytest.raises(ValueError, match="link-local"):
+    with pytest.raises(ValueError, match="private address|link-local"):
         validate_ollama_url("http://169.254.169.254/latest", True)
 
 
@@ -80,9 +80,11 @@ def test_validate_ollama_url_ipv6_bracket():
 
 
 def test_validate_ollama_url_user_pass():
-    # Test URL with user:pass
-    # http://user:pass@localhost:11434
-    url, headers = validate_ollama_url("http://user:pass@localhost:11434", False)
-    assert "user:pass@" in url
-    assert "127.0.0.1" in url or "::1" in url
-    assert headers["Host"] == "localhost:11434"
+    # URLs with inline credentials are forbidden.
+    with pytest.raises(ValueError, match="must not include username/password"):
+        validate_ollama_url("http://user:pass@localhost:11434", False)
+
+
+def test_validate_ollama_url_private_ip_blocked_when_remote_enabled():
+    with pytest.raises(ValueError, match="private address"):
+        validate_ollama_url("http://10.0.0.2:11434", True)


### PR DESCRIPTION
## Summary
This PR implements the review-finding fixes and adds an MLX-specific long-rerun estimate, aligned with the Qwen 3.5 (`mlx_lm`) pipeline introduced in PR #65.

It also keeps paper references anonymous for double-blind review and includes a citation/source audit report generated from `paper/references.bib`.

## What Changed
- Security hardening for LLM endpoint validation (credential/private-address checks).
- Harmony pipeline fixes for:
  - grounding validation,
  - persistent archive reuse,
  - cost-aware value objective,
  - island migration behavior alignment.
- Tests added/updated for the above behavior.
- Paper consistency edits (claims, counts, wording, citations) and anonymized dataset citation metadata.
- Added source audit tooling:
  - `scripts/audit_paper_sources.py`
  - `docs/paper_source_audit.md`
- Added MLX runtime estimate note:
  - `docs/mlx_long_rerun_estimate_2026-03-04.md`

## Revised Long-Rerun Estimate (Qwen 3.5 via MLX)
Assuming 5 domains, 10 seeds, and full Block-A refresh:
- Best case: **8-10h**
- Expected: **10-14h**
- Worst case: **18-30h**

Basis and derivation are documented in:
- `docs/mlx_long_rerun_estimate_2026-03-04.md`

## Validation
- `uv run --group dev ruff check .`
- `uv run --group dev ruff format --check .`
- `uv run --group dev pytest -q`
- `cd paper && tectonic -r 2 main.tex`

## Constraints Honored
- No edits under archive paths (`paper/archive/**`, `artifacts/**`, `zenodo_staging/**`).
- No long-running reruns were started in this PR.

## Post-Merge Options
1. **Run full MLX long rerun now (Recommended)**
   - Execute 5-domain x 10-seed reruns + Block-A refresh in one overnight batch.
2. **Run calibration-first, then full rerun**
   - First run 1 domain x 2 seeds to measure actual min/domain-run, then rescale and launch full rerun with corrected ETA.
3. **Run staged confirmation only**
   - Prioritize domains tied to strongest claims first; defer lower-impact domains to a follow-up batch.
4. **Increase parallelism cautiously**
   - Use >1 worker to reduce wall-clock, accepting possible throughput contention and higher tail-risk.
